### PR TITLE
add msgTransparentSelf property

### DIFF
--- a/SOUI/include/core/SWnd.h
+++ b/SOUI/include/core/SWnd.h
@@ -290,6 +290,7 @@ class SOUI_EXP SWindow
     STDMETHOD_(void, SetVisible)(THIS_ BOOL bVisible, BOOL bUpdate DEF_VAL(FALSE)) OVERRIDE;
 
     STDMETHOD_(BOOL, IsMsgTransparent)(THIS) SCONST OVERRIDE;
+    STDMETHOD_(BOOL, IsMsgTransparentSelf)(THIS) SCONST OVERRIDE;
 
     STDMETHOD_(ULONG_PTR, GetUserData)(THIS) SCONST OVERRIDE;
     STDMETHOD_(ULONG_PTR, SetUserData)(THIS_ ULONG_PTR uData) OVERRIDE;
@@ -1170,6 +1171,7 @@ class SOUI_EXP SWindow
 		ATTR_CUSTOM(L"videoCanvas",OnAttrVideoCanvas)
         ATTR_CUSTOM(L"tip", OnAttrTip)
         ATTR_BOOL(L"msgTransparent", m_bMsgTransparent, FALSE)
+        ATTR_BOOL(L"msgTransparentSelf", m_bMsgTransparentSelf, FALSE)
         ATTR_LAYOUTSIZE(L"maxWidth", m_nMaxWidth, FALSE)
         ATTR_BOOL(L"clipClient", m_bClipClient, FALSE)
         ATTR_BOOL(L"focusable", m_bFocusable, FALSE)
@@ -1243,6 +1245,7 @@ class SOUI_EXP SWindow
     m_bClipClient : 1;           /**<
                                     窗口绘制时做clip客户区处理的标志,由于clip可能增加计算量，只在绘制可能走出客户区时才设置*/
     DWORD m_bMsgTransparent : 1; /**< 接收消息标志 TRUE-不处理消息 */
+    DWORD m_bMsgTransparentSelf : 1; /**< 接收消息标志 TRUE-不处理消息本身消息但是依旧处理child消息 */
     DWORD m_bFocusable : 1;      /**< 窗口可获得焦点标志 */
     DWORD m_bDrawFocusRect : 1;  /**< 绘制默认的焦点虚框 */
     DWORD m_bCacheDraw : 1;      /**< 支持窗口内容的Cache标志 */

--- a/SOUI/include/interface/SWindow-i.h
+++ b/SOUI/include/interface/SWindow-i.h
@@ -91,6 +91,7 @@ DECLARE_INTERFACE_(IWindow, IObject)
      * @return TRUE--鼠标消息透传给父窗口
      */
     STDMETHOD_(BOOL, IsMsgTransparent)(CTHIS) SCONST PURE;
+    STDMETHOD_(BOOL, IsMsgTransparentSelf)(CTHIS) SCONST PURE;
 
     /**
      * @brief 获取窗口是否自动剪裁客户区

--- a/SOUI/src/core/Swnd.cpp
+++ b/SOUI/src/core/Swnd.cpp
@@ -658,6 +658,11 @@ BOOL SWindow::IsMsgTransparent() const
     return m_bMsgTransparent;
 }
 
+BOOL SWindow::IsMsgTransparentSelf() const
+{
+    return m_bMsgTransparentSelf;
+}
+
 const SwndStyle &SWindow::GetStyle() const
 {
     return m_style;
@@ -1018,6 +1023,10 @@ SWND SWindow::SwndFromPoint(CPoint &pt, BOOL bIncludeMsgTransparent) const
         }
 
         pChild = pChild->GetWindow(GSW_PREVSIBLING);
+    }
+    if (IsMsgTransparentSelf() && !bIncludeMsgTransparent)
+    {
+        return NULL;
     }
     pt = pt2; // update pt;
     return m_swnd;

--- a/components/ScriptModule-LUA/src/exports/exp_IWindow.h
+++ b/components/ScriptModule-LUA/src/exports/exp_IWindow.h
@@ -18,7 +18,8 @@ BOOL ExpLua_IWindow(lua_State *L)
 		lua_tinker::class_def<IWindow>(L,"SetLayoutParam",&IWindow::SetLayoutParam);
 		lua_tinker::class_def<IWindow>(L,"IsFloat",&IWindow::IsFloat);
 		lua_tinker::class_def<IWindow>(L,"IsDisplay",&IWindow::IsDisplay);
-		lua_tinker::class_def<IWindow>(L,"IsMsgTransparent",&IWindow::IsMsgTransparent);
+        lua_tinker::class_def<IWindow>(L,"IsMsgTransparent", &IWindow::IsMsgTransparent);
+        lua_tinker::class_def<IWindow>(L,"IsMsgTransparentSelf", &IWindow::IsMsgTransparentSelf);
 		lua_tinker::class_def<IWindow>(L,"IsClipClient",&IWindow::IsClipClient);
 		lua_tinker::class_def<IWindow>(L,"SetToolTipText",&IWindow::SetToolTipText);
 		lua_tinker::class_def<IWindow>(L,"IsChecked",&IWindow::IsChecked);


### PR DESCRIPTION
add msgTransparentSelf property to let the windows just skip itself's message but do not skip its child's message.
 添加 `msgTransparentSelf ` 属性.
这个属性可以让窗口忽略发送到本身的消息,但是如果这个消息可以被子窗口处理则依旧处理子窗口消息.

使用场景:
```
<SOUI name="main_window" title="%title% ver:%ver%" width="600" height="400" appWnd="1" margin="5, 5, 5, 5"  resizable="1" translucent="1" >
    <root>
        <caption pos="0,0,-0,-0">
             <!--如果使用msgTransparent="1", 那么可以在任何地方移动窗口,但是其子窗口失去响应-->
            <window pos="5,5,-5,@30" trackMouseEvent="1" colorBkgnd="#00000000" msgTransparentSelf="1">
                <imgbtn name="btn_close" skin="_skin.sys.btn.close" pos="-45,0" tip="close" animate="1"/>
                <imgbtn name="btn_max" skin="_skin.sys.btn.maximize" pos="-83,0" animate="1" />
                <imgbtn name="btn_restore" skin="_skin.sys.btn.restore" pos="-83,0" show="0" animate="1" />
                <imgbtn name="btn_min" skin="_skin.sys.btn.minimize" pos="-121,0" animate="1" />
            </window>
        </caption>
    </root>
</SOUI>

```