### PR TITLE
fix SListBox size not full fill the outside SComboBox bug

### DIFF
--- a/SOUI/src/control/SComboBox.cpp
+++ b/SOUI/src/control/SComboBox.cpp
@@ -38,6 +38,7 @@ BOOL SComboBox::CreateListBox(SXmlNode xmlNode)
         m_pListBox->SetAttribute(L"margin", L"1,1,1,1");
         m_pListBox->SetAttribute(L"hotTrack", L"1", TRUE);
     }
+    m_pListBox->SetAttribute(L"pos", L"0,0,-0,-0", TRUE);
     m_pListBox->SetOwner(this); // chain notify message to combobox
     m_pListBox->SetVisible(FALSE);
     m_pListBox->SetID(IDC_DROPDOWN_LIST);


### PR DESCRIPTION
BOOL SComboBox::CreateListBox(SXmlNode xmlNode) 里面追加一句    m_pListBox->SetAttribute(L"pos", L"0,0,-0,-0", TRUE); 让下拉列表框里面的m_pListBox和父SComboBox一样大小。请看图：
before
<img width="1332" height="975" alt="image" src="https://github.com/user-attachments/assets/2e0e4765-16bc-4294-ab4f-399957b10abe" />
after
<img width="1332" height="975" alt="image" src="https://github.com/user-attachments/assets/12a62f54-59c4-4617-a5c2-c524edae84f3" />
这样改是否正确呢？